### PR TITLE
Display owner initials on front of card

### DIFF
--- a/public/stylesheets/pivotal-cards.css
+++ b/public/stylesheets/pivotal-cards.css
@@ -143,14 +143,16 @@
 }
 
 .epic_name {
-  float: left;
+  display: block;
+  width: 100%;
+  text-align: center;
   text-transform: uppercase;
 }
 
 .points {
-  float: right;
-  position: relative;
+  position: absolute;
   top: -4.5mm;
+  right: 0;
   font-size: 9mm;
   font-weight: bold;
 }
@@ -198,6 +200,18 @@
   font-weight: bold;
 }
 
+.fronts .owner {
+  position: absolute;
+  top: -4.5mm;
+  float: none;
+  font-size: 9mm;
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+.fronts .owner:before {
+  content: none;
+}
 
 /*
  *  cards for story-type

--- a/views/cards.erb
+++ b/views/cards.erb
@@ -26,6 +26,9 @@
             </div>
             <div class="footer">
               <span class="epic_name"></span>
+              <% if story.owned_by %>
+                <span class="owner"><%= story.owned_by.to_s.split(/[\.\- ]/).map{|s|s[0]}.join('') %></span>
+              <% end %>
               <% if story.estimate and story.estimate > 0 %>
                 <span class="points points<%= story.estimate %>"><span><%= story.estimate %></span></span>
               <% end %>


### PR DESCRIPTION
As we wanted to glance across the room at the cards and see who has which card, I've added owner initials to the bottom left at the front and moved the epic name to the bottom centre (see image).

![card_with_initials_on_front](https://f.cloud.github.com/assets/157556/1929371/9090d212-7e96-11e3-8928-832c3dac4fe9.png)

By the way, thanks for making card-o-matic in the first place - we :heart: it!
