### PR TITLE
QR codes for easy linking

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -75,6 +75,8 @@ class CardOMatic < Sinatra::Base
       @project.iterations(options).first.stories
     end
 
+    @with_qr_codes = params[:with_qr_codes] == 'true'
+
     if @stories.any?
       erb :cards, :layout => false
     else

--- a/public/stylesheets/pivotal-cards.css
+++ b/public/stylesheets/pivotal-cards.css
@@ -319,3 +319,17 @@
 .white-backs .backs .card .side .footer {
   background-color: #ffffff;
 }
+
+.qr-code {
+  width: 20mm;
+  height: inherit;
+  display: inline-block;
+  position: relative;
+}
+
+.qr-image {
+  position: absolute;
+  width: 20mm;
+  bottom: 0;
+  left: 0;
+}

--- a/views/cards.erb
+++ b/views/cards.erb
@@ -24,7 +24,9 @@
               <div class="story-type"><%= story.story_type %></div>
             </div>
             <div class="footer">
-              <span class="epic_name"></span>
+              <span class="qr-code">
+                <img src="http://zxing.org/w/chart?cht=qr&chs=120x120&chld=L&choe=UTF-8&chl=https%3A%2F%2Fwww.pivotaltracker.com%2Fstory%2Fshow%2F<%= story.id %>" alt="Link to pivotal story" class="qr-image"/>
+              </span>
               <% if story.labels.any? %>
                 <span class="labels">
                   <% story.labels.each do |label| %>

--- a/views/cards.erb
+++ b/views/cards.erb
@@ -24,9 +24,11 @@
               <div class="story-type"><%= story.story_type %></div>
             </div>
             <div class="footer">
-              <span class="qr-code">
-                <img src="http://zxing.org/w/chart?cht=qr&chs=120x120&chld=L&choe=UTF-8&chl=https%3A%2F%2Fwww.pivotaltracker.com%2Fstory%2Fshow%2F<%= story.id %>" alt="Link to pivotal story" class="qr-image"/>
-              </span>
+              <% if @with_qr_codes %>
+                <span class="qr-code">
+                  <img src="http://zxing.org/w/chart?cht=qr&chs=120x120&chld=L&choe=UTF-8&chl=https%3A%2F%2Fwww.pivotaltracker.com%2Fstory%2Fshow%2F<%= story.id %>" alt="Link to pivotal story" class="qr-image"/>
+                </span>
+              <% end %>
               <% if story.labels.any? %>
                 <span class="labels">
                   <% story.labels.each do |label| %>

--- a/views/iterations.erb
+++ b/views/iterations.erb
@@ -36,6 +36,18 @@
       </li>
     <% end %>
   </ul>
+
+  <p>Would you like QR codes on the cards?</p>
+
+  <ul>
+    <li>
+      <label>
+        <input type="checkbox" id="with_qr_codes" name="with_qr_codes" value="true">
+        Include QR codes linking to the story
+      </label>
+    </li>
+  </ul>
+
   <p>
     <button type="submit">Generate these cards <span>(opens in a new window)</span></button>
     <input type="hidden" name="project_id" value="<%= @project.id %>" />


### PR DESCRIPTION
At Land Registry the team keep asking to add short story codes (like TS67) to the stories to make them easier to find in the backlog. This pull request adds (optionally) QR codes to the cards so you can easily find the story using a smartphone. It might not fully solve the problem but it might help.

Added option to create QR codes
![screen shot 2015-03-19 at 17 12 35](https://cloud.githubusercontent.com/assets/1446145/6736166/0eafefb0-ce5b-11e4-82cf-f6c4909d1439.png)

QR codes on the actual cards
![screen shot 2015-03-19 at 17 12 49](https://cloud.githubusercontent.com/assets/1446145/6736176/1d284740-ce5b-11e4-9f15-7d25b0fab185.png)
