### PR TITLE
Print specific stories

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -67,6 +67,11 @@ class CardOMatic < Sinatra::Base
       @project.stories(with_state: "unscheduled", fields: ':default,owners')
     when 'backlog'
       @project.iterations(scope: 'backlog', fields: ':default,stories(:default,owners)').first.stories
+    when 'specific_stories'
+      story_ids = params[:story_ids].split(',')
+      story_ids.map do |story_id|
+        @project.story(story_id.to_i)
+      end
     when /\d+/
       iteration = params[:iteration].to_i
       options = { limit: 1 }

--- a/views/iterations.erb
+++ b/views/iterations.erb
@@ -22,6 +22,18 @@
         </div>
       </label>
     </li>
+    <li>
+      <label for="iteration_specfic">
+        <input type="radio" id="iteration_specific" name="iteration" value="specific_stories" />
+        <div class="iteration">
+          Specific Stories
+          <label for="iteration_specific_ids">
+            Comma-separated list of Story IDs
+            <input type="text" id="iteration_specific_ids" name="story_ids" />
+          </label>
+        </div>
+      </label>
+    </li>
   </ul>
 
   <ul>


### PR DESCRIPTION
When updating pivotal it's a pain to have to print an entire iteration for one or two changes. This adds in an option of printing individual cards by providing a comma separated list of IDs.

Entering IDs:
![screen shot 2015-03-24 at 10 53 13](https://cloud.githubusercontent.com/assets/1446145/6800137/d3f12198-d213-11e4-89b9-644c0640f3d4.png)

Rendered cards
![screen shot 2015-03-24 at 10 51 33](https://cloud.githubusercontent.com/assets/1446145/6800138/d4069fa0-d213-11e4-9b00-a1035e3febe8.png)
